### PR TITLE
Set safe production values for new servers

### DIFF
--- a/uber_config/events/stock/2023/staging/init.yaml
+++ b/uber_config/events/stock/2023/staging/init.yaml
@@ -1,0 +1,14 @@
+plugins:
+  uber:
+    at_the_con: False
+    post_con: False
+    shirt_stock: 0
+    supporter_stock: 0
+    season_stock: 0
+
+    dates:
+      prereg_open: 2023-01-01
+      dealer_reg_start: 2023-01-01
+      volunteer_checklist_open: 2023-01-01
+      mivs_start: 2023-01-01
+      panels_start: 2023-01-01

--- a/uber_config/events/super/2024/init.yaml
+++ b/uber_config/events/super/2024/init.yaml
@@ -1,9 +1,9 @@
 plugins:
   uber:
     app_limit: 0
-    shirt_stock: 980
-    supporter_stock: 715
-    season_stock: 530
+    shirt_stock: 0
+    supporter_stock: 0
+    season_stock: 0
     shared_kickin_stocks: False
     groups_enabled: True
     blank_staff_badges: 200
@@ -58,7 +58,7 @@ plugins:
     music_rooms: ['concerts', 'chiptunes', 'pose_lounge', 'lobby_bar', 'jamspace', 'jam_clinic', 'jam_shop', 'rock_island']
 
     dates:
-      prereg_open: 2023-09-28 15
+      prereg_open: 2024-01-05 15
       prereg_hotel_eligibility_cutoff: 2023-10-05
       volunteer_checklist_open: 2023-10-10
       shifts_created: 2023-11-16
@@ -85,7 +85,7 @@ plugins:
       # sent in the days and weeks leading up to DEALER_PAYMENT_DUE.  All waitlisted dealers will
       # be emailed when the waitlist has been exhausted and all available positions have been
       # filled, as defined by DEALER_WAITLIST_CLOSED.
-      dealer_reg_start: 2023-08-26 20
+      dealer_reg_start: 2024-01-05 20
       dealer_reg_deadline: ''
       dealer_reg_shutdown: 2023-08-27 20
       dealer_payment_due: 2023-12-04

--- a/uber_config/events/super/2024/staging/init.yaml
+++ b/uber_config/events/super/2024/staging/init.yaml
@@ -1,0 +1,15 @@
+plugins:
+  uber:
+    at_the_con: False
+    post_con: False
+    shirt_stock: 0
+    supporter_stock: 0
+    season_stock: 0
+
+    dates:
+      prereg_open: 2023-01-01
+      dealer_reg_start: 2023-01-01
+      volunteer_checklist_open: 2023-01-01
+      mivs_start: 2023-01-01
+      panels_start: 2023-01-01
+      

--- a/uber_config/events/west/2023/init.yaml
+++ b/uber_config/events/west/2023/init.yaml
@@ -1,8 +1,8 @@
 plugins:
   uber:
-    shirt_stock: 100
-    supporter_stock: 50
-    season_stock: 50
+    shirt_stock: 0
+    supporter_stock: 0
+    season_stock: 0
     shared_kickin_stocks: False
     event_year: 2023
     max_dealers: 5
@@ -35,7 +35,7 @@ plugins:
       prereg_takedown: 2023-07-13
       group_prereg_takedown: 2023-07-13
       placeholder_deadline: 2023-07-16
-      prereg_open: 2023-04-17
+      prereg_open: 2023-07-14
       shifts_created: 2023-05-15
       shirt_deadline: 2023-06-15
       volunteer_shirt_deadline: 2023-06-23
@@ -52,7 +52,7 @@ plugins:
       # sent in the days and weeks leading up to DEALER_PAYMENT_DUE.  All waitlisted dealers will
       # be emailed when the waitlist has been exhausted and all available positions have been
       # filled, as defined by DEALER_WAITLIST_CLOSED.
-      dealer_reg_start: 2023-03-01
+      dealer_reg_start: 2023-07-14
       dealer_reg_shutdown: 2023-04-30
       dealer_payment_due: 2023-06-01
       dealer_reg_deadline: ""  # Disable automatic waitlist

--- a/uber_config/events/west/2023/staging/init.yaml
+++ b/uber_config/events/west/2023/staging/init.yaml
@@ -1,0 +1,14 @@
+plugins:
+  uber:
+    at_the_con: False
+    post_con: False
+    shirt_stock: 0
+    supporter_stock: 0
+    season_stock: 0
+
+    dates:
+      prereg_open: 2023-01-01
+      dealer_reg_start: 2023-01-01
+      volunteer_checklist_open: 2023-01-01
+      mivs_start: 2023-01-01
+      panels_start: 2023-01-01


### PR DESCRIPTION
Our informal policy is that, until we're reasonably sure we're on a good timeline for reg launch, we set dates that couldn't possibly have us opening reg too early. This does that and also adds config to each event's staging server to override those dates so we can better preview things.

Note that Stock already had the right config set up for safety, so I didn't need to change it.