### PR TITLE
Update staging server URLs

### DIFF
--- a/servers.yaml
+++ b/servers.yaml
@@ -1,7 +1,7 @@
 staging:
-  stock2023:
+  stock:
     ubersystem_container: ghcr.io/magfest/magstock:main
-    hostname: stock2023.dev.magevent.net
+    hostname: stock.dev.magevent.net
     zonename: dev.magevent.net
     prefix: stock23
     config_paths:
@@ -10,9 +10,9 @@ staging:
     enable_workers: false
     layout: single
 
-  west2023:
+  west:
     ubersystem_container: ghcr.io/magfest/magwest:main
-    hostname: west2023.dev.magevent.net
+    hostname: west.dev.magevent.net
     zonename: dev.magevent.net
     prefix: west23
     config_paths:


### PR DESCRIPTION
We don't do yearly staging servers so it's easier if they have year-agnostic URLs.