### PR TITLE
Revert "Update staging server URLs"

### DIFF
--- a/servers.yaml
+++ b/servers.yaml
@@ -1,7 +1,7 @@
 staging:
-  stock:
+  stock2023:
     ubersystem_container: ghcr.io/magfest/magstock:main
-    hostname: stock.dev.magevent.net
+    hostname: stock2023.dev.magevent.net
     zonename: dev.magevent.net
     prefix: stock23
     config_paths:
@@ -10,9 +10,9 @@ staging:
     enable_workers: false
     layout: single
 
-  west:
+  west2023:
     ubersystem_container: ghcr.io/magfest/magwest:main
-    hostname: west.dev.magevent.net
+    hostname: west2023.dev.magevent.net
     zonename: dev.magevent.net
     prefix: west23
     config_paths:


### PR DESCRIPTION
Reverts magfest/terraform-aws-magfest#4. This broke the staging servers so maybe if I undo it they'll work...?