### PR TITLE
Add missing 'allotments' for West 2019

### DIFF
--- a/uber_config/events/west/2019/init.yaml
+++ b/uber_config/events/west/2019/init.yaml
@@ -176,6 +176,9 @@ plugins:
 
       allotments:
         deadline: 2019-08-15
+        name: Treasury Information
+        description: If you need cash and/or mpoints, tell us your department schedule and your specific cash needs.
+        path: /dept_checklist/allotments?department_id={department_id}
         
       office_supplies:
         deadline: 2019-08-22


### PR DESCRIPTION
This department head checklist step was removed from the main config at some point, causing fatal errors on the server