### PR TITLE
Add missing badge types for Stock 2019

### DIFF
--- a/uber_config/events/stock/init.yaml
+++ b/uber_config/events/stock/init.yaml
@@ -90,6 +90,8 @@ plugins:
         attendee_badge: Attendee
         staff_badge: Staff
         guest_badge: Guest
+        contractor_badge: Contractor
+        child_badge: Minor
 
       job_interest:
         misc: General Support


### PR DESCRIPTION
These badge types are actually defined in configspec.ini, but our older server doesn't have the updated base config so we have to define it here.