### PR TITLE
Update band checklist deadlines

### DIFF
--- a/uber_config/events/stock/2023/init.yaml
+++ b/uber_config/events/stock/2023/init.yaml
@@ -50,11 +50,14 @@ plugins:
       dealer_reg_deadline: ""  # Disable automatic waitlist
       dealer_waitlist_closed: ""  # If this is enabled, be sure to update the waitlist_closing.txt email
       
-      band_bio_deadline: 2023-05-10
-      band_info_deadline: 2023-05-10
-      band_taxes_deadline: 2023-05-10
-      band_badges_deadline: 2023-05-10
-      band_stage_plot_deadline: 2023-05-10
+      band_panel_deadline: ""
+      band_merch_deadline: ""
+      band_charity_deadline: ""
+      band_info_deadline: ""
+      band_taxes_deadline: ""
+      band_bio_deadline: 2023-05-15
+      band_stage_plot_deadline: 2023-05-22
+      band_badges_deadline: 2023-05-29
       
     badge_prices:
       initial_attendee: 180


### PR DESCRIPTION
Turns off most steps and updates the deadline for the remaining steps.