### PR TITLE
Move West merch from event config to yearly config

### DIFF
--- a/uber_config/events/west/2022/init.yaml
+++ b/uber_config/events/west/2022/init.yaml
@@ -131,6 +131,13 @@ plugins:
         min_age: 5
         max_age: 11
         can_volunteer: False
+        
+    integer_enums:
+      donation_tier:
+        No thanks: 0
+        T-Shirt Bundle: SHIRT_LEVEL
+        Supporter Package: SUPPORTER_LEVEL
+        Jet Tier: SEASON_LEVEL
 
     donation_tier_descriptions:
       no_thanks:

--- a/uber_config/events/west/init.yaml
+++ b/uber_config/events/west/init.yaml
@@ -154,9 +154,6 @@ plugins:
 
       donation_tier:
         No thanks: 0
-        T-Shirt Bundle: SHIRT_LEVEL
-        Supporter Package: SUPPORTER_LEVEL
-        Jet Tier: SEASON_LEVEL
         
     dept_head_checklist:
       creating_shifts:


### PR DESCRIPTION
This will fix the admin interface showing old preordered merch tiers