### PR TITLE
Fix Super treasury checklist URL

### DIFF
--- a/uber_config/events/super/2024/init.yaml
+++ b/uber_config/events/super/2024/init.yaml
@@ -29,7 +29,7 @@ plugins:
 
     alt_schedule_url: https://guidebook.com/guide/101720/schedule
 
-    treasury_dept_checklist_form_url: "https://super2024.dev.magevent.net/static_views/treasury_form.html"
+    treasury_dept_checklist_form_url: https://super2024.reg.magfest.org/static_views/treasury_form.html
     volunteer_perks_url: https://www.notion.so/magfest/MAGFest-Super-Perks-f001221c31484ef4957a6513c54a6fd6
     staff_room_faq_url: https://www.notion.so/magfest/Staff-Room-FAQ-656edde68e324dae97891c2002439465
 

--- a/uber_config/events/super/2024/staging/init.yaml
+++ b/uber_config/events/super/2024/staging/init.yaml
@@ -6,6 +6,7 @@ plugins:
     shirt_stock: 5
     supporter_stock: 5
     season_stock: 5
+    treasury_dept_checklist_form_url: https://super.dev.magevent.net/static_views/treasury_form.html
 
     dates:
       panels_start: 2023-08-11


### PR DESCRIPTION
Somehow this had gotten set to a staging URL, and also it was a staging URL we don't use. Now it links to the server's real URL.