### PR TITLE
Add consent form to attendees 6-12

### DIFF
--- a/uber_config/events/super/2024/init.yaml
+++ b/uber_config/events/super/2024/init.yaml
@@ -191,6 +191,7 @@ plugins:
         desc: "Between 6 and 12"
         min_age: 6
         max_age: 11
+        consent_form: True
         can_volunteer: False
 
       under_13:


### PR DESCRIPTION
The age group we configured for 6 to 12 year old attendees didn't include giving them the consent form, so some of our emails didn't mention it when they should have. This fixes that.