### PR TITLE
Split staff/contractor badges

### DIFF
--- a/uber_config/events/super/2024/init.yaml
+++ b/uber_config/events/super/2024/init.yaml
@@ -148,8 +148,8 @@ plugins:
 
     badge_ranges:
       # Staff_badge and contractor_badge should be split to start with, then merged after we send badges to the printer
-      staff_badge: [25, 2999]
-      contractor_badge: [25, 2999]
+      staff_badge: [25, 1500]
+      contractor_badge: [1501, 2999]
       guest_badge: [3000, 3499]
       attendee_badge: [3500, 29999]
       one_day_badge: [40000, 49999]


### PR DESCRIPTION
Temporarily splits the staff and contractor badge ranges for the badge export.