### PR TITLE
Stop using registration/register at-con

### DIFF
--- a/uber_config/events/super/2024/init.yaml
+++ b/uber_config/events/super/2024/init.yaml
@@ -21,6 +21,7 @@ plugins:
     post_con: False
     covid_policies_url: 'https://super.magfest.org/covid'
     prior_covid_policies_url: ''
+    kiosk_redirect_url: ''
     accessibility_services_enabled: False
     slow_load_check: False
     tracking_params: ['fbclid', 'hsmi', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', '_hsmi', '_home', '_hsenc']

--- a/uber_config/events/super/2024/staging/init.yaml
+++ b/uber_config/events/super/2024/staging/init.yaml
@@ -1,7 +1,7 @@
 plugins:
   uber:
     url_root: https://super.dev.magevent.net/
-    at_the_con: False
+    at_the_con: True
     post_con: False
     shirt_stock: 5
     supporter_stock: 5


### PR DESCRIPTION
We don't need to switch off the prereg pages anymore as we don't have public kiosks. Also sets staging to at-con mode.