### PR TITLE
Demo - Implement Datadog

### DIFF
--- a/datadog.tf
+++ b/datadog.tf
@@ -13,7 +13,7 @@ resource "aws_ssm_document" "datadog_install" {
         "name": "install",
         "inputs": {
           "runCommand": [
-            "DD_API_KEY=$(aws secretsmanager get-secret-value --secret-id ${aws_secretsmanager_secret.datadog_api_key.name}) DD_SITE="datadoghq.com" bash -c \"$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)\""
+            "DD_API_KEY=$(aws secretsmanager get-secret-value --secret-id ${aws_secretsmanager_secret.datadog_api_key[0].name}) DD_SITE="datadoghq.com" bash -c \"$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)\""
           ]
         }
       }
@@ -21,7 +21,7 @@ resource "aws_ssm_document" "datadog_install" {
   }
   EOF
 
-  depends_on = [ aws_secretsmanager_secret_version.datadog_api_key ]
+  depends_on = [ aws_secretsmanager_secret_version.datadog_api_key[0] ]
   count = var.datadog_api_key != null ? 0 : 1
 }
 
@@ -32,7 +32,7 @@ resource "aws_secretsmanager_secret" "datadog_api_key" {
 }
 
 resource "aws_secretsmanager_secret_version" "datadog_api_key" {
-  secret_id     = aws_secretsmanager_secret.datadog_api_key.id
+  secret_id     = aws_secretsmanager_secret.datadog_api_key[0].id
   secret_string = var.datadog_api_key
 
   count = var.datadog_api_key != null ? 0 : 1

--- a/datadog.tf
+++ b/datadog.tf
@@ -22,18 +22,18 @@ resource "aws_ssm_document" "datadog_install" {
   EOF
 
   depends_on = [ aws_secretsmanager_secret_version.datadog_api_key[0] ]
-  count = var.datadog_api_key != null ? 0 : 1
+  count = var.datadog_api_key != null ? 1 : 0
 }
 
 resource "aws_secretsmanager_secret" "datadog_api_key" {
   name_prefix = "datadog-"
 
-  count = var.datadog_api_key != null ? 0 : 1
+  count = var.datadog_api_key != null ? 1 : 0
 }
 
 resource "aws_secretsmanager_secret_version" "datadog_api_key" {
   secret_id     = aws_secretsmanager_secret.datadog_api_key[0].id
   secret_string = var.datadog_api_key
 
-  count = var.datadog_api_key != null ? 0 : 1
+  count = var.datadog_api_key != null ? 1 : 0
 }

--- a/datadog.tf
+++ b/datadog.tf
@@ -12,7 +12,7 @@ resource "aws_ssm_document" "datadog_install" {
         "action": "aws:runShellScript",
         "name": "install",
         "inputs": {
-          "runCommand": [
+          "runCommand": [ 
             "DD_API_KEY=$(aws secretsmanager get-secret-value --secret-id ${aws_secretsmanager_secret.datadog_api_key[0].name}) DD_SITE="datadoghq.com" bash -c \"$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)\""
           ]
         }

--- a/datadog.tf
+++ b/datadog.tf
@@ -1,5 +1,16 @@
 # Docs: https://aws.amazon.com/blogs/mt/packaging-to-distribution-using-aws-systems-manager-distributor-to-deploy-datadog/
 
+resource "aws_ssm_association" "datadog_install" {
+  name = aws_ssm_document.datadog_install[0].name
+
+  targets {
+    key    = "tag:randomized-cluster-name"
+    values = [ random_string.ecs_cluster.result ]
+  }
+
+  count = var.datadog_api_key != null ? 1 : 0
+}
+
 resource "aws_ssm_document" "datadog_install" {
   name          = "DatadogInstall"
   document_type = "Command"

--- a/datadog.tf
+++ b/datadog.tf
@@ -1,0 +1,39 @@
+# Docs: https://aws.amazon.com/blogs/mt/packaging-to-distribution-using-aws-systems-manager-distributor-to-deploy-datadog/
+
+resource "aws_ssm_document" "datadog_install" {
+  name          = "DatadogInstall"
+  document_type = "Command"
+  content = <<EOF
+  {
+    "schemaVersion": "2.2",
+    "description": "Install the Datadog Agent",
+    "mainSteps": [
+      {
+        "action": "aws:runShellScript",
+        "name": "install",
+        "inputs": {
+          "runCommand": [
+            "DD_API_KEY=$(aws secretsmanager get-secret-value --secret-id ${aws_secretsmanager_secret.datadog_api_key.name}) DD_SITE="datadoghq.com" bash -c \"$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)\""
+          ]
+        }
+      }
+    ]
+  }
+  EOF
+
+  depends_on = [ aws_secretsmanager_secret_version.datadog_api_key ]
+  count = var.datadog_api_key != null ? 0 : 1
+}
+
+resource "aws_secretsmanager_secret" "datadog_api_key" {
+  name_prefix = "datadog-"
+
+  count = var.datadog_api_key != null ? 0 : 1
+}
+
+resource "aws_secretsmanager_secret_version" "datadog_api_key" {
+  secret_id     = aws_secretsmanager_secret.datadog_api_key.id
+  secret_string = var.datadog_api_key
+
+  count = var.datadog_api_key != null ? 0 : 1
+}

--- a/ecs.tf
+++ b/ecs.tf
@@ -191,6 +191,11 @@ resource "aws_ecs_account_setting_default" "account_settings" {
   value = "enabled"
 }
 
+resource "random_string" "ecs_cluster" {
+  length           = 16
+  special          = false
+}
+
 resource "aws_autoscaling_group" "ecs_cluster" {
   name_prefix = "${var.clustername}_asg_"
   termination_policies = [
@@ -213,6 +218,11 @@ resource "aws_autoscaling_group" "ecs_cluster" {
   tag {
     key                 = "AmazonECSManaged"
     value               = true
+    propagate_at_launch = true
+  }
+  tag {
+    key                 = "randomized-cluster-name"
+    value               = random_string.ecs_cluster.result
     propagate_at_launch = true
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,10 @@ variable "mq_instance_size" {
     type    = string
     default = "mq.t3.micro"
 }
+
+variable "datadog_api_key" {
+    type        = string
+    description = "If set, the Datadog agent will be installed and configured with this API key."
+    sensitive   = true
+    default     = null
+}


### PR DESCRIPTION
This will add Datadog as an agent on each ECS EC2 node by injecting via a SSM document.